### PR TITLE
Make oracle compliant for building from source

### DIFF
--- a/opensearch-operator/BUILD_FROM_SOURCE_README.md
+++ b/opensearch-operator/BUILD_FROM_SOURCE_README.md
@@ -1,6 +1,6 @@
 # Build Instructions
 
-The base tag, this release is branched from is `v2.2.1`
+The base tag, this release is branched from is `v2.4.0`
 
 
 Create Environment Variables
@@ -8,7 +8,7 @@ Create Environment Variables
 ```
 export DOCKER_REPO=<Docker Repository>
 export DOCKER_NAMESPACE=<Docker Namespace>
-export DOCKER_TAG=v2.2.1
+export DOCKER_TAG=v2.4.0
 ```
 
 Build and Push Images

--- a/opensearch-operator/BUILD_FROM_SOURCE_README.md
+++ b/opensearch-operator/BUILD_FROM_SOURCE_README.md
@@ -1,0 +1,21 @@
+# Build Instructions
+
+The base tag, this release is branched from is `v2.2.1`
+
+
+Create Environment Variables
+
+```
+export DOCKER_REPO=<Docker Repository>
+export DOCKER_NAMESPACE=<Docker Namespace>
+export DOCKER_TAG=v2.2.1
+```
+
+Build and Push Images
+
+```
+# Build and push opensearch-k8s-operator
+
+docker build -t ${DOCKER_REPO}/${DOCKER_NAMESPACE}/opensearch-k8s-operator:${DOCKER_TAG} .
+docker push ${DOCKER_REPO}/${DOCKER_NAMESPACE}/opensearch-k8s-operator:${DOCKER_TAG}
+```

--- a/opensearch-operator/Dockerfile.oracle
+++ b/opensearch-operator/Dockerfile.oracle
@@ -1,0 +1,37 @@
+# Build the manager binary
+FROM  ghcr.io/oracle/oraclelinux:8-slim as builder
+
+RUN microdnf update -y \
+    && microdnf -y install golang \
+    && microdnf clean all
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/   pkg/
+COPY opensearch-gateway/   opensearch-gateway/
+
+# Build
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM ghcr.io/oracle/oraclelinux:8-slim
+WORKDIR /
+COPY --from=builder /workspace/manager .
+RUN mkdir /license
+COPY BUILD_FROM_SOURCE_README.md  SECURITY.md THIRD_PARTY_LICENSES.txt /license/
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -75,6 +75,11 @@ docker-build: generate fmt vet ## Build docker image with the manager.
 	go install opensearch.opster.io/pkg/helpers
 	DOCKER_BUILDKIT=1 docker build -t ${IMG} .
 
+docker-build-oracle: generate fmt vet ## Build docker image with the manager.
+	go install opensearch.opster.io/pkg/builders
+	go install opensearch.opster.io/pkg/helpers
+	DOCKER_BUILDKIT=1 docker build -t ${IMG} -f Dockerfile.oracle .
+
 docker-build-multiarch: ## Build docker image with the manager for all supported architectures
 	go install opensearch.opster.io/pkg/builders
 	go install opensearch.opster.io/pkg/helpers

--- a/opensearch-operator/SECURITY.md
+++ b/opensearch-operator/SECURITY.md
@@ -1,0 +1,17 @@
+# Reporting Security Vulnerabilities
+
+Oracle values the independent security research community and believes that responsible disclosure of security vulnerabilities helps us ensure the security and privacy of all our users.
+
+Please do NOT raise a GitHub Issue to report a security vulnerability. If you believe you have found a security vulnerability, please submit a report to secalert_us@oracle.com preferably with a proof of concept. We provide additional information on [how to report security vulnerabilities to Oracle](https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html) which includes public encryption keys for secure email.
+
+We ask that you do not use other channels or contact project contributors directly.
+
+Non-vulnerability related security issues such as new great new ideas for security features are welcome on GitHub Issues.
+
+## Security Updates, Alerts and Bulletins
+
+Security updates will be released on a regular cadence. Many of our projects will typically release security fixes in conjunction with the [Oracle Critical Patch Update](https://www.oracle.com/security-alerts/) program. Security updates are released on the Tuesday closest to the 17th day of January, April, July and October. A pre-release announcement will be published on the Thursday preceding each release. Additional information, including past advisories, is available on our [Security Alerts](https://www.oracle.com/security-alerts/) page.
+
+## Security-Related Information
+
+We will provide security related information such as a threat model, considerations for secure use, or any known security issues in our documentation. Please note that labs and sample code are intended to demonstrate a concept and may not be sufficiently hardened for production use.

--- a/opensearch-operator/THIRD_PARTY_LICENSES.txt
+++ b/opensearch-operator/THIRD_PARTY_LICENSES.txt
@@ -1,0 +1,2120 @@
+=== Public License Template ===
+opensearch.opster.io
+-------- Copyrights
+  (no copyright notices found)
+
+-------- License
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright {yyyy} {name of copyright owner}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+gopkg.in/yaml.v3
+-------- Copyrights
+Copyright (c) 2011-2019 Canonical Ltd
+Copyright (c) 2006-2010 Kirill Simonov
+Copyright (c) 2006-2011 Kirill Simonov
+Copyright 2011-2016 Canonical Ltd.
+-------- Notices
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+-------- Dependencies Summary
+gopkg.in/yaml.v3
+
+-------- License used by Dependencies
+
+This project is covered by two different licenses: MIT and Apache.
+
+#### MIT License ####
+
+The following files were ported to Go from C files of libyaml, and thus
+are still covered by their original MIT license, with the additional
+copyright staring in 2011 when the project was ported over:
+
+    apic.go emitterc.go parserc.go readerc.go scannerc.go
+    writerc.go yamlh.go yamlprivateh.go
+
+Copyright (c) 2006-2010 Kirill Simonov
+Copyright (c) 2006-2011 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### Apache License ###
+
+All the remaining project files are covered by the Apache license:
+
+Copyright (c) 2011-2019 Canonical Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+cloud.google.com/go
+-------- Copyrights
+Copyright 2016 Google LLC
+Copyright 2019 Google LLC
+Copyright 2018 Google LLC
+Copyright (c) 1996-1998 John D. Polstra.  All rights reserved.
+Copyright (c) 2001 David E. O'Brien
+Copyright 2018 Google LLC.
+Copyright 2021 Google LLC
+Copyright 2014 Google LLC
+Copyright 2018 Google Inc. All Rights Reserved.
+Copyright 2017 Google LLC
+Copyright 2020 Google LLC
+Copyright 2020, Google LLC
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2012 Google, Inc. Package foo does bar.", 27, ""},
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright (c) 2020 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+
+-------- Dependency
+github.com/Azure/go-autorest/autorest
+-------- Copyrights
+Copyright 2017 Microsoft Corporation
+Copyright 2015 Microsoft Corporation
+
+-------- Dependency
+github.com/Azure/go-autorest/autorest/adal
+-------- Copyrights
+Copyright 2017 Microsoft Corporation
+Copyright 2015 Microsoft Corporation
+
+-------- Dependency
+github.com/Azure/go-autorest/autorest/date
+-------- Copyrights
+Copyright 2017 Microsoft Corporation
+Copyright 2015 Microsoft Corporation
+
+-------- Dependency
+github.com/Azure/go-autorest/logger
+-------- Copyrights
+Copyright 2017 Microsoft Corporation
+Copyright 2015 Microsoft Corporation
+
+-------- Dependency
+github.com/Azure/go-autorest/tracing
+-------- Copyrights
+Copyright 2018 Microsoft Corporation
+Copyright 2017 Microsoft Corporation
+Copyright 2015 Microsoft Corporation
+
+-------- Dependency
+github.com/banzaicloud/k8s-objectmatcher
+-------- Copyrights
+Copyright (c) 2017-2019 [Banzai Cloud, Inc.](https://banzaicloud.com)
+Copyright © 2019 Banzai Cloud
+Copyright © 2021 Banzai Cloud
+Copyright © 2022 Banzai Cloud
+-------- Notices
+Copyright © 2019 Banzai Cloud
+
+Portions of this software were developed in the Kubernetes project: https://github.com/kubernetes/kubernetes
+
+The source file patch/annotation.go is based on https://github.com/kubernetes/kubernetes/blob/3d0c961d57bb90c112a0ee2f5ccdcb5c8570ad32/pkg/kubectl/apply.go
+The source file patch/deletenull.go is based on https://github.com/kubernetes/kubernetes/blob/433b448e8d42da70df5d50f4ce667bcb36aeeec2/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
+
+
+-------- Dependency
+github.com/banzaicloud/operator-tools
+-------- Copyrights
+Copyright © 2020 Banzai Cloud
+Copyright © 2022 Banzai Cloud
+
+-------- Dependency
+github.com/briandowns/spinner
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependency
+github.com/go-logr/logr
+-------- Copyrights
+Copyright 2020 The logr Authors.
+Copyright 2021 The logr Authors.
+Copyright 2019 The logr Authors.
+
+-------- Dependency
+github.com/go-logr/zapr
+-------- Copyrights
+Copyright 2019 The logr Authors.
+Copyright 2021 The logr Authors.
+Copyright 2018 Solly Ross
+Copyright 2020 The Kubernetes Authors.
+
+-------- Dependency
+github.com/go-openapi/jsonpointer
+-------- Copyrights
+Copyright 2013 sigu-399 ( https://github.com/sigu-399 )
+
+-------- Dependency
+github.com/go-openapi/jsonreference
+-------- Copyrights
+Copyright 2013 sigu-399 ( https://github.com/sigu-399 )
+
+-------- Dependency
+github.com/go-openapi/swag
+-------- Copyrights
+Copyright 2015 go-swagger maintainers
+
+-------- Dependency
+github.com/golang/groupcache
+-------- Copyrights
+Copyright 2012 Google Inc.
+Copyright 2013 Google Inc.
+
+-------- Dependency
+github.com/google/gnostic
+-------- Copyrights
+Copyright 2017-2020, Google LLC.
+Copyright 2019 Google LLC. All Rights Reserved.
+Copyright 2017 Google LLC. All Rights Reserved.
+Copyright 2018 Google LLC. All Rights Reserved.
+Copyright 2020 Google LLC. All Rights Reserved.
+Copyright 2020 Google LLC. All Rights Reserved.\n" +
+
+-------- Dependency
+github.com/google/gofuzz
+-------- Copyrights
+Copyright 2014 Google Inc. All rights reserved.
+
+-------- Dependency
+github.com/matttproud/golang_protobuf_extensions
+-------- Copyrights
+Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+Copyright 2016 Matt T. Proud
+Copyright 2013 Matt T. Proud
+-------- Notices
+Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+
+
+-------- Dependency
+github.com/modern-go/concurrent
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependency
+github.com/modern-go/reflect2
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependency
+github.com/opensearch-project/opensearch-go
+-------- Copyrights
+Copyright 2021 OpenSearch Contributors
+-------- Notices
+OpenSearch (https://opensearch.org/)
+Copyright 2021 OpenSearch Contributors
+
+This product includes software developed by
+Elasticsearch (http://www.elastic.co).
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).
+
+-------- Dependency
+github.com/prometheus/client_golang
+-------- Copyrights
+Copyright 2018 The Prometheus Authors
+Copyright 2012-2015 The Prometheus Authors
+Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
+Copyright 2010 The Go Authors
+Copyright 2013 Matt T. Proud
+Copyright 2015 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2022 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2014 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
+Copyright (c) 2013, The Prometheus Authors
+-------- Notices
+Prometheus instrumentation library for Go applications
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+The following components are included in this product:
+
+perks - a fork of https://github.com/bmizerany/perks
+https://github.com/beorn7/perks
+Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
+See https://github.com/beorn7/perks/blob/master/README.md for license details.
+
+Go support for Protocol Buffers - Google's data interchange format
+http://github.com/golang/protobuf/
+Copyright 2010 The Go Authors
+See source code for license details.
+
+Support for streaming Protocol Buffer messages for the Go language (golang).
+https://github.com/matttproud/golang_protobuf_extensions
+Copyright 2013 Matt T. Proud
+Licensed under the Apache License, Version 2.0
+
+
+-------- Dependency
+github.com/prometheus/client_model
+-------- Copyrights
+Copyright 2013 Prometheus Team
+Copyright 2012-2015 The Prometheus Authors
+-------- Notices
+Data model artifacts for Prometheus.
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+-------- Dependency
+github.com/prometheus/common
+-------- Copyrights
+Copyright 2018 The Prometheus Authors
+Copyright 2015 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
+Copyright 2014 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+Copyright 2013 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+-------- Notices
+Common libraries shared by Prometheus Go components.
+Copyright 2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+-------- Dependency
+github.com/prometheus/procfs
+-------- Copyrights
+Copyright 2019 The Prometheus Authors
+Copyright 2018 The Prometheus Authors
+Copyright 2014-2015 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2014 Prometheus Team
+Copyright 2017 Prometheus Team
+-------- Notices
+procfs provides functions to retrieve system, kernel and process
+metrics from the pseudo-filesystem proc.
+
+Copyright 2014-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+-------- Dependency
+gomodules.xyz/jsonpatch/v2
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependency
+gopkg.in/yaml.v2
+-------- Copyrights
+Copyright 2011-2016 Canonical Ltd.
+Copyright (c) 2006 Kirill Simonov
+-------- Notices
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+-------- Dependency
+k8s.io/api
+-------- Copyrights
+Copyright 2019 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+
+-------- Dependency
+k8s.io/apiextensions-apiserver
+-------- Copyrights
+Copyright 2019 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Google LLC
+Copyright 2022 Google LLC
+
+-------- Dependency
+k8s.io/apimachinery
+-------- Copyrights
+Copyright 2021 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+
+-------- Dependency
+k8s.io/client-go
+-------- Copyrights
+Copyright 2021 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+-------- Dependency
+k8s.io/component-base
+-------- Copyrights
+Copyright 2014 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+
+-------- Dependency
+k8s.io/klog/v2
+-------- Copyrights
+Copyright 2022 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2013 Google Inc. All Rights Reserved.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 Intel Coporation.
+
+-------- Dependency
+k8s.io/kube-openapi
+-------- Copyrights
+Copyright 2018 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright (c) 2020 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2015 go-swagger maintainers
+Copyright 2017 go-swagger maintainers
+
+-------- Dependency
+k8s.io/utils
+-------- Copyrights
+Copyright 2018 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright 2013 Google Inc.
+Copyright 2009 The Go Authors. All rights reserved.
+
+-------- Dependency
+sigs.k8s.io/controller-runtime
+-------- Copyrights
+Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2018 The Kubernetes authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+
+-------- Dependency
+sigs.k8s.io/structured-merge-diff/v4
+-------- Copyrights
+Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+
+-------- Dependencies Summary
+cloud.google.com/go
+github.com/Azure/go-autorest/autorest
+github.com/Azure/go-autorest/autorest/adal
+github.com/Azure/go-autorest/autorest/date
+github.com/Azure/go-autorest/logger
+github.com/Azure/go-autorest/tracing
+github.com/banzaicloud/k8s-objectmatcher
+github.com/banzaicloud/operator-tools
+github.com/briandowns/spinner
+github.com/go-logr/logr
+github.com/go-logr/zapr
+github.com/go-openapi/jsonpointer
+github.com/go-openapi/jsonreference
+github.com/go-openapi/swag
+github.com/golang/groupcache
+github.com/google/gnostic
+github.com/google/gofuzz
+github.com/matttproud/golang_protobuf_extensions
+github.com/modern-go/concurrent
+github.com/modern-go/reflect2
+github.com/opensearch-project/opensearch-go
+github.com/prometheus/client_golang
+github.com/prometheus/client_model
+github.com/prometheus/common
+github.com/prometheus/procfs
+gomodules.xyz/jsonpatch/v2
+gopkg.in/yaml.v2
+k8s.io/api
+k8s.io/apiextensions-apiserver
+k8s.io/apimachinery
+k8s.io/client-go
+k8s.io/component-base
+k8s.io/klog/v2
+k8s.io/kube-openapi
+k8s.io/utils
+sigs.k8s.io/controller-runtime
+sigs.k8s.io/structured-merge-diff/v4
+
+-------- License used by Dependencies
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with
+that entity. For the purposes of this definition, "control" means (i) the
+power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+(50%) or more of the outstanding shares, or (iii) beneficial ownership of such
+entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative
+Works shall not include works that remain separable from, or merely link (or
+bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated
+in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any
+part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy of
+the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part of
+the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the
+Derivative Works, if and wherever such third-party notices normally appear.
+The contents of the NOTICE file are for informational purposes only and do not
+modify the License. You may add Your own attribution notices within Derivative
+Works that You distribute, alongside or as an addendum to the NOTICE text from
+the Work, provided that such additional attribution notices cannot be
+construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don&apos;t include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+github.com/munnerz/goautoneg
+-------- Copyrights
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+
+-------- Dependencies Summary
+github.com/munnerz/goautoneg
+
+-------- License used by Dependencies
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+    Neither the name of the Open Knowledge Foundation Ltd. nor the
+    names of its contributors may be used to endorse or promote
+    products derived from this software without specific prior written
+    permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+github.com/PuerkitoBio/purell
+-------- Copyrights
+Copyright (c) 2012, Martin Angers
+
+-------- Dependencies Summary
+github.com/PuerkitoBio/purell
+
+-------- License used by Dependencies
+Copyright (c) 2012, Martin Angers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+github.com/evanphx/json-patch
+-------- Copyrights
+Copyright (c) 2014, Evan Phoenix
+
+-------- Dependency
+github.com/evanphx/json-patch/v5
+-------- Copyrights
+Copyright (c) 2014, Evan Phoenix
+
+-------- Dependencies Summary
+github.com/evanphx/json-patch
+github.com/evanphx/json-patch/v5
+
+-------- License used by Dependencies
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+sigs.k8s.io/json
+-------- Copyrights
+Copyright 2021 The Kubernetes Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+
+-------- Dependencies Summary
+sigs.k8s.io/json
+
+-------- License used by Dependencies
+Files other than internal/golang/* licensed under: Apache 2.0 (See actual license text in main license section above)
+
+------------------
+
+internal/golang/* files licensed under:
+
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+github.com/davecgh/go-spew
+-------- Copyrights
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
+Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
+Copyright (c) 2013 Dave Collins <dave@davec.name>
+
+-------- Dependencies Summary
+github.com/davecgh/go-spew
+
+-------- License used by Dependencies
+ISC License
+
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+github.com/hashicorp/go-version
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependencies Summary
+github.com/hashicorp/go-version
+
+-------- License used by Dependencies
+Mozilla Public License Version 2.0
+
+1. Definitions
+
+1.1. "Contributor" means each individual or legal entity that creates,
+contributes to the creation of, or owns Covered Software.
+
+1.2. "Contributor Version" means the combination of the Contributions of
+others (if any) used by a Contributor and that particular Contributor&apos;s
+Contribution.
+
+1.3. "Contribution" means Covered Software of a particular Contributor.
+
+1.4. "Covered Software" means Source Code Form to which the initial
+Contributor has attached the notice in Exhibit A, the Executable Form of such
+Source Code Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses" means
+
+(a) that the initial Contributor has attached the notice described in Exhibit
+B to the Covered Software; or
+
+(b) that the Covered Software was made available under the terms of version
+1.1 or earlier of the License, but not also under the terms of a Secondary
+License.
+
+1.6. "Executable Form" means any form of the work other than Source Code Form.
+
+1.7. "Larger Work" means a work that combines Covered Software with other
+material, in a separate file or files, that is not Covered Software.
+
+1.8. "License" means this document.
+
+1.9. "Licensable" means having the right to grant, to the maximum extent
+possible, whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
+
+1.10. "Modifications" means any of the following:
+
+(a) any file in Source Code Form that results from an addition to, deletion
+from, or modification of the contents of Covered Software; or
+
+(b) any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor means any patent claim(s), including
+without limitation, method, process, and apparatus claims, in any patent
+Licensable by such Contributor that would be infringed, but for the grant of
+the License, by the making, using, selling, offering for sale, having made,
+import, or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License" means either the GNU General Public License, Version
+2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero
+General Public License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form" means the form of the work preferred for making
+modifications.
+
+1.14. "You" (or "Your") means an individual or a legal entity exercising
+rights under this License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For purposes
+of this definition, "control" means (a) the power, direct or indirect, to
+cause the direction or management of such entity, whether by contract or
+otherwise, or (b) ownership of more than fifty percent (50%) of the
+outstanding shares or beneficial ownership of such entity.
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive
+license:
+
+(a) under intellectual property rights (other than patent or trademark)
+Licensable by such Contributor to use, reproduce, make available, modify,
+display, perform, distribute, and otherwise exploit its Contributions, either
+on an unmodified basis, with Modifications, or as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer for
+sale, have made, import, and otherwise transfer either its Contributions or
+its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution become
+effective for each Contribution on the date the Contributor first distributes
+such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under this
+License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software; or
+
+(b) for infringements caused by: (i) Your and any other third party&apos;s
+modifications of Covered Software, or (ii) the combination of its
+Contributions with other software (except as part of its Contributor Version);
+or
+
+(c) under Patent Claims infringed by Covered Software in the absence of its
+Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or
+logos of any Contributor (except as may be necessary to comply with the notice
+requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this License
+(see Section 10.2) or under the terms of a Secondary License (if permitted
+under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its Contributions
+are its original creation(s) or it has sufficient rights to grant the rights
+to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under applicable
+copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+Section 2.1.
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under the
+terms of this License. You must inform recipients that the Source Code Form of
+the Covered Software is governed by the terms of this License, and how they
+can obtain a copy of this License. You may not attempt to alter or restrict
+the recipients&apos; rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code Form, as
+described in Section 3.1, and You must inform recipients of the Executable
+Form how they can obtain a copy of such Source Code Form by reasonable means
+in a timely manner, at a charge no more than the cost of distribution to the
+recipient; and
+
+(b) You may distribute such Executable Form under the terms of this License,
+or sublicense it under different terms, provided that the license for the
+Executable Form does not attempt to limit or alter the recipients&apos; rights
+in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for the
+Covered Software. If the Larger Work is a combination of Covered Software with
+a work governed by one or more Secondary Licenses, and the Covered Software is
+not Incompatible With Secondary Licenses, this License permits You to
+additionally distribute such Covered Software under the terms of such
+Secondary License(s), so that the recipient of the Larger Work may, at their
+option, further distribute the Covered Software under the terms of either this
+License or such Secondary License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices (including
+copyright notices, patent notices, disclaimers of warranty, or limitations of
+liability) contained within the Source Code Form of the Covered Software,
+except that You may alter any license notices to the extent required to remedy
+known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support, indemnity
+or liability obligations to one or more recipients of Covered Software.
+However, You may do so only on Your own behalf, and not on behalf of any
+Contributor. You must make it absolutely clear that any such warranty,
+support, indemnity, or liability obligation is offered by You alone, and You
+hereby agree to indemnify every Contributor for any liability incurred by such
+Contributor as a result of warranty, support, indemnity or liability terms You
+offer. You may include additional disclaimers of warranty and limitations of
+liability specific to any jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+If it is impossible for You to comply with any of the terms of this License
+with respect to some or all of the Covered Software due to statute, judicial
+order, or regulation then You must: (a) comply with the terms of this License
+to the maximum extent possible; and (b) describe the limitations and the code
+they affect. Such description must be placed in a text file included with all
+distributions of the Covered Software under this License. Except to the extent
+prohibited by statute or regulation, such description must be sufficiently
+detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+fail to comply with any of its terms. However, if You become compliant, then
+the rights granted under this License from a particular Contributor are
+reinstated (a) provisionally, unless and until such Contributor explicitly and
+finally terminates Your grants, and (b) on an ongoing basis, if such
+Contributor fails to notify You of the non-compliance by some reasonable means
+prior to 60 days after You have come back into compliance. Moreover, Your
+grants from a particular Contributor are reinstated on an ongoing basis if
+such Contributor notifies You of the non-compliance by some reasonable means,
+this is the first time You have received notice of non-compliance with this
+License from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions, counter-claims,
+and cross-claims) alleging that a Contributor Version directly or indirectly
+infringes any patent, then the rights granted to You by any and all
+Contributors for the Covered Software under Section 2.1 of this License shall
+terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+license agreements (excluding distributors and resellers) which have been
+validly granted by You or Your distributors under this License prior to
+termination shall survive termination.
+
+6. Disclaimer of Warranty
+Covered Software is provided under this License on an "as is" basis, without
+warranty of any kind, either expressed, implied, or statutory, including,
+without limitation, warranties that the Covered Software is free of defects,
+merchantable, fit for a particular purpose or non-infringing. The entire risk
+as to the quality and performance of the Covered Software is with You. Should
+any Covered Software prove defective in any respect, You (not any Contributor)
+assume the cost of any necessary servicing, repair, or correction. This
+disclaimer of warranty constitutes an essential part of this License. No use
+of any Covered Software is authorized under this License except under this
+disclaimer.
+
+7. Limitation of Liability
+Under no circumstances and under no legal theory, whether tort (including
+negligence), contract, or otherwise, shall any Contributor, or anyone who
+distributes Covered Software as permitted above, be liable to You for any
+direct, indirect, special, incidental, or consequential damages of any
+character including, without limitation, damages for lost profits, loss of
+goodwill, work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses, even if such party shall have been informed of
+the possibility of such damages. This limitation of liability shall not apply
+to liability for death or personal injury resulting from such party&apos;s
+negligence to the extent applicable law prohibits such limitation. Some
+jurisdictions do not allow the exclusion or limitation of incidental or
+consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+Any litigation relating to this License may be brought only in the courts of a
+jurisdiction where the defendant maintains its principal place of business and
+such litigation shall be governed by laws of that jurisdiction, without
+reference to its conflict-of-law provisions. Nothing in this Section shall
+prevent a party&apos;s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+This License represents the complete agreement concerning the subject matter
+hereof. If any provision of this License is held to be unenforceable, such
+provision shall be reformed only to the extent necessary to make it
+enforceable. Any law or regulation which provides that the language of a
+contract shall be construed against the drafter shall not be used to construe
+this License against a Contributor.
+
+10. Versions of the License
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section 10.3,
+no one other than the license steward has the right to modify or publish new
+versions of this License. Each version will be given a distinguishing version
+number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version of the
+License under which You originally received the Covered Software, or under the
+terms of any subsequent version published by the license steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to create a
+new license for such software, you may create and use a modified version of
+this License if you rename the license and remove any references to the name
+of the license steward (except to note that such modified license differs from
+this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the notice
+described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. If a copy of the MPL was not distributed with this file, You can
+obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+This Source Code Form is "Incompatible With Secondary Licenses", as defined by
+the Mozilla Public License, v. 2.0.
+
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+emperror.dev/errors
+-------- Copyrights
+Copyright (c) 2019 Márk Sági-Kazár <mark.sagikazar@gmail.com>
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+Copyright (c) 2019 The Go Authors. All rights reserved.
+Copyright 2015 Dave Cheney <dave@cheney.net>. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+
+-------- Dependency
+github.com/Masterminds/semver
+-------- Copyrights
+Copyright (C) 2014-2019, Matt Butcher and Matt Farina
+
+-------- Dependency
+github.com/beorn7/perks
+-------- Copyrights
+Copyright (C) 2013 Blake Mizerany
+
+-------- Dependency
+github.com/cespare/xxhash/v2
+-------- Copyrights
+Copyright (c) 2016 Caleb Spare
+
+-------- Dependency
+github.com/cppforlife/go-patch
+-------- Copyrights
+Copyright (c) 2016 Dmitriy Kalinin
+
+-------- Dependency
+github.com/emicklei/go-restful/v3
+-------- Copyrights
+Copyright 2013 Ernest Micklei. All rights reserved.
+Copyright 2015 Ernest Micklei. All rights reserved.
+Copyright (c) 2012,2013 Ernest Micklei
+Copyright 2021 Ernest Micklei. All rights reserved.
+Copyright 2014 Ernest Micklei. All rights reserved.
+Copyright 2018 Ernest Micklei. All rights reserved.
+
+-------- Dependency
+github.com/fatih/color
+-------- Copyrights
+Copyright (c) 2013 Fatih Arslan
+
+-------- Dependency
+github.com/golang-jwt/jwt/v4
+-------- Copyrights
+Copyright (c) 2012 Dave Grijalva
+Copyright (c) 2021 golang-jwt maintainers
+
+-------- Dependency
+github.com/iancoleman/orderedmap
+-------- Copyrights
+Copyright (c) 2017 Ian Coleman
+
+-------- Dependency
+github.com/josharian/intern
+-------- Copyrights
+Copyright (c) 2019 Josh Bleecher Snyder
+
+-------- Dependency
+github.com/json-iterator/go
+-------- Copyrights
+Copyright (c) 2016 json-iterator
+
+-------- Dependency
+github.com/mailru/easyjson
+-------- Copyrights
+Copyright (c) 2016 Mail.Ru Group
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+-------- Dependency
+github.com/mattn/go-colorable
+-------- Copyrights
+Copyright (c) 2016 Yasuhiro Matsumoto
+
+-------- Dependency
+github.com/mattn/go-isatty
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependency
+github.com/spf13/cast
+-------- Copyrights
+Copyright © 2014 Steve Francia <spf@spf13.com>.
+Copyright (c) 2014 Steve Francia
+Copyright 2011 The Go Authors. All rights reserved.
+
+-------- Dependency
+github.com/wayneashleyberry/terminal-dimensions
+-------- Copyrights
+Copyright (c) 2016 Wayne Ashley Berry
+
+-------- Dependency
+go.uber.org/atomic
+-------- Copyrights
+Copyright (c) 2020 Uber Technologies, Inc.
+Copyright (c) 2016 Uber Technologies, Inc.
+Copyright (c) 2016-2020 Uber Technologies, Inc.
+
+-------- Dependency
+go.uber.org/multierr
+-------- Copyrights
+Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2019 Uber Technologies, Inc.
+
+-------- Dependency
+go.uber.org/zap
+-------- Copyrights
+Copyright (c) 2016 Uber Technologies, Inc.
+Copyright (c) 2016-2017 Uber Technologies, Inc.
+Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2020 Uber Technologies, Inc.
+Copyright (c) 2021 Uber Technologies, Inc.
+Copyright (c) 2016, 2017 Uber Technologies, Inc.
+Copyright (c) 2018 Uber Technologies, Inc.
+
+-------- Dependencies Summary
+emperror.dev/errors
+github.com/Masterminds/semver
+github.com/beorn7/perks
+github.com/cespare/xxhash/v2
+github.com/cppforlife/go-patch
+github.com/emicklei/go-restful/v3
+github.com/fatih/color
+github.com/golang-jwt/jwt/v4
+github.com/iancoleman/orderedmap
+github.com/josharian/intern
+github.com/json-iterator/go
+github.com/mailru/easyjson
+github.com/mattn/go-colorable
+github.com/mattn/go-isatty
+github.com/spf13/cast
+github.com/wayneashleyberry/terminal-dimensions
+go.uber.org/atomic
+go.uber.org/multierr
+go.uber.org/zap
+
+-------- License used by Dependencies
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+github.com/PuerkitoBio/urlesc
+-------- Copyrights
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+-------- Dependency
+github.com/fsnotify/fsnotify
+-------- Copyrights
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+
+-------- Dependency
+github.com/gogo/protobuf
+-------- Copyrights
+Copyright (c) 2013, The GoGo Authors. All rights reserved.
+Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2010 The Go Authors.
+Copyright (c) 2015, The GoGo Authors. All rights reserved.
+Copyright 2016 The Go Authors.  All rights reserved.
+Copyright 2015 The Go Authors.  All rights reserved.
+Copyright (c) 2018, The GoGo Authors. All rights reserved.
+Copyright 2011 The Go Authors.  All rights reserved.
+Copyright (c) 2016, The GoGo Authors. All rights reserved.
+Copyright 2018 The Go Authors.  All rights reserved.
+Copyright 2017 The Go Authors.  All rights reserved.
+Copyright 2014 The Go Authors.  All rights reserved.
+Copyright 2012 The Go Authors.  All rights reserved.
+Copyright 2013 The Go Authors.  All rights reserved.
+Copyright (c) 2019, The GoGo Authors. All rights reserved.
+Copyright (c) 2017, The GoGo Authors. All rights reserved.
+Copyright (c) 2015, The GoGo Authors.  rights reserved.
+
+-------- Dependency
+github.com/golang/protobuf
+-------- Copyrights
+Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors.  All rights reserved.
+
+-------- Dependency
+github.com/google/go-cmp
+-------- Copyrights
+Copyright (c) 2017 The Go Authors. All rights reserved.
+Copyright 2018, The Go Authors. All rights reserved.
+Copyright 2017, The Go Authors. All rights reserved.
+Copyright 2020, The Go Authors. All rights reserved.
+Copyright 2019, The Go Authors. All rights reserved.
+
+-------- Dependency
+github.com/google/uuid
+-------- Copyrights
+Copyright 2016 Google Inc.  All rights reserved.
+Copyright 2017 Google Inc.  All rights reserved.
+Copyright 2021 Google Inc.  All rights reserved.
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+Copyright 2018 Google Inc.  All rights reserved.
+
+-------- Dependency
+github.com/imdario/mergo
+-------- Copyrights
+Copyright 2013 Dario Castañé. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright (c) 2013 Dario Castañé. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright 2014 Dario Castañé. All rights reserved.
+
+-------- Dependency
+github.com/spf13/pflag
+-------- Copyrights
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors.  All rights reserved.
+
+-------- Dependency
+golang.org/x/crypto
+-------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright (c) 2017 The Go Authors. All rights reserved.
+Copyright (c) 2019 The Go Authors. All rights reserved.
+Copyright (c) 2021 The Go Authors. All rights reserved.
+Copyright (c) 2020 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
+golang.org/x/net
+-------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright (C) 2009 Apple Inc. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
+golang.org/x/oauth2
+-------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2017 The oauth2 Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2015 The oauth2 Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2018 The oauth2 Authors. All rights reserved.
+
+-------- Dependency
+golang.org/x/sys
+-------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2009,2010 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All right reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
+golang.org/x/term
+-------- Copyrights
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
+golang.org/x/text
+-------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
+golang.org/x/time
+-------- Copyrights
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
+google.golang.org/protobuf
+-------- Copyrights
+Copyright (c) 2018 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.",
+Copyright 2018 The Go Authors. All rights reserved.",
+Copyright 2008 Google Inc.  All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+-------- Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+-------- Dependency
+gopkg.in/inf.v0
+-------- Copyrights
+Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+
+-------- Dependencies Summary
+github.com/PuerkitoBio/urlesc
+github.com/fsnotify/fsnotify
+github.com/gogo/protobuf
+github.com/golang/protobuf
+github.com/google/go-cmp
+github.com/google/uuid
+github.com/imdario/mergo
+github.com/spf13/pflag
+golang.org/x/crypto
+golang.org/x/net
+golang.org/x/oauth2
+golang.org/x/sys
+golang.org/x/term
+golang.org/x/text
+golang.org/x/time
+google.golang.org/protobuf
+gopkg.in/inf.v0
+
+-------- License used by Dependencies
+Redistribution and use in source and binary forms, with
+or without modification, are permitted provided that the following conditions
+are met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+github.com/pkg/errors
+-------- Copyrights
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+
+-------- Dependencies Summary
+github.com/pkg/errors
+
+-------- License used by Dependencies
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+sigs.k8s.io/yaml
+-------- Copyrights
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright (c) 2014 Sam Ghods
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+-------- Dependencies Summary
+sigs.k8s.io/yaml
+
+-------- License used by Dependencies
+The MIT License (MIT)
+
+Copyright (c) 2014 Sam Ghods
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+=== ATTRIBUTION-HELPER-GENERATED:
+=== Attribution helper version: {Major:0 Minor:11 GitVersion:0.10.0-58-gdde2e03d GitCommit:dde2e03d0114e01b7189b036162a1340f9e630e8 GitTreeState:clean BuildDate:2022-09-19T14:22:19Z GoVersion:go1.19.1 Compiler:gc Platform:darwin/amd64}
+=== License file based on go.mod with md5 sum: 009cd43a782b56499b37ed96fd38fa66

--- a/opensearch-operator/THIRD_PARTY_LICENSES.txt
+++ b/opensearch-operator/THIRD_PARTY_LICENSES.txt
@@ -1,222 +1,1310 @@
 === Public License Template ===
 opensearch.opster.io
--------- Copyrights
-  (no copyright notices found)
 
--------- License
+------------------------------ Top-Level License -------------------------------
+SPDX:Apache-2.0
 
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
+---------------------------------- Copyright -----------------------------------
+Copyright 2022 The Kubernetes authors.
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+-------------------------- Fourth Party Dependencies ---------------------------
 
-1. Definitions.
+----------------------------------- Licenses -----------------------------------
+-  Apache-2.0
+-  BSD-2-Clause
+-  BSD-3-Clause
+-  BSD-3-Clause--modified-by-Google
+-  ISC
+-  MIT
+-  MPL-2.0
 
-"License" shall mean the terms and conditions for use, reproduction,
-and distribution as defined by Sections 1 through 9 of this document.
+--------------------------------- (separator) ----------------------------------
 
-"Licensor" shall mean the copyright owner or entity authorized by
-the copyright owner that is granting the License.
+== Dependency
+emperror.dev/errors
 
-"Legal Entity" shall mean the union of the acting entity and all
-other entities that control, are controlled by, or are under common
-control with that entity. For the purposes of this definition,
-"control" means (i) the power, direct or indirect, to cause the
-direction or management of such entity, whether by contract or
-otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
+== License Type
+SPDX:MIT
 
-"You" (or "Your") shall mean an individual or Legal Entity
-exercising permissions granted by this License.
+== Copyright
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+Copyright (c) 2019 Márk Sági-Kazár <mark.sagikazar@gmail.com>
+Copyright (c) 2019 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2015 Dave Cheney <dave@cheney.net>. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
 
-"Source" form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation
-source, and configuration files.
+--------------------------------- (separator) ----------------------------------
 
-"Object" form shall mean any form resulting from mechanical
-transformation or translation of a Source form, including but
-not limited to compiled object code, generated documentation,
-and conversions to other media types.
+--------------------------------- (separator) ----------------------------------
 
-"Work" shall mean the work of authorship, whether in Source or
-Object form, made available under the License, as indicated by a
-copyright notice that is included in or attached to the work
-(an example is provided in the Appendix below).
+== Dependency
+github.com/Masterminds/semver
 
-"Derivative Works" shall mean any work, whether in Source or Object
-form, that is based on (or derived from) the Work and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship. For the purposes
-of this License, Derivative Works shall not include works that remain
-separable from, or merely link (or bind by name) to the interfaces of,
-the Work and Derivative Works thereof.
+== License Type
+SPDX:MIT
 
-"Contribution" shall mean any work of authorship, including
-the original version of the Work and any modifications or additions
-to that Work or Derivative Works thereof, that is intentionally
-submitted to Licensor for inclusion in the Work by the copyright owner
-or by an individual or Legal Entity authorized to submit on behalf of
-the copyright owner. For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, the
-Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise
-designated in writing by the copyright owner as "Not a Contribution."
+== Copyright
+Copyright (C) 2014-2019, Matt Butcher and Matt Farina
 
-"Contributor" shall mean Licensor and any individual or Legal Entity
-on behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.
+--------------------------------- (separator) ----------------------------------
 
-2. Grant of Copyright License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the
-Work and such Derivative Works in Source or Object form.
+== Dependency
+github.com/beorn7/perks
 
-3. Grant of Patent License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made,
-use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable
-by such Contributor that are necessarily infringed by their
-Contribution(s) alone or by combination of their Contribution(s)
-with the Work to which such Contribution(s) was submitted. If You
-institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work
-or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate
-as of the date such litigation is filed.
+== License Type
+SPDX:MIT
 
-4. Redistribution. You may reproduce and distribute copies of the
-Work or Derivative Works thereof in any medium, with or without
-modifications, and in Source or Object form, provided that You
-meet the following conditions:
+== Copyright
+Copyright (C) 2013 Blake Mizerany
 
-(a) You must give any other recipients of the Work or
-Derivative Works a copy of this License; and
+--------------------------------- (separator) ----------------------------------
 
-(b) You must cause any modified files to carry prominent notices
-stating that You changed the files; and
+== Dependency
+github.com/briandowns/spinner
 
-(c) You must retain, in the Source form of any Derivative Works
-that You distribute, all copyright, patent, trademark, and
-attribution notices from the Source form of the Work,
-excluding those notices that do not pertain to any part of
-the Derivative Works; and
+== License Type
+SPDX:Apache-2.0
 
-(d) If the Work includes a "NOTICE" text file as part of its
-distribution, then any Derivative Works that You distribute must
-include a readable copy of the attribution notices contained
-within such NOTICE file, excluding those notices that do not
-pertain to any part of the Derivative Works, in at least one
-of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or
-documentation, if provided along with the Derivative Works; or,
-within a display generated by the Derivative Works, if and
-wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and
-do not modify the License. You may add Your own attribution
-notices within Derivative Works that You distribute, alongside
-or as an addendum to the NOTICE text from the Work, provided
-that such additional attribution notices cannot be construed
-as modifying the License.
+== Copyright
+(no copyright notices found)
 
-You may add Your own copyright statement to Your modifications and
-may provide additional or different license terms and conditions
-for use, reproduction, or distribution of Your modifications, or
-for any such Derivative Works as a whole, provided Your use,
-reproduction, and distribution of the Work otherwise complies with
-the conditions stated in this License.
+--------------------------------- (separator) ----------------------------------
 
-5. Submission of Contributions. Unless You explicitly state otherwise,
-any Contribution intentionally submitted for inclusion in the Work
-by You to the Licensor shall be under the terms and conditions of
-this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify
-the terms of any separate license agreement you may have executed
-with Licensor regarding such Contributions.
+== Dependency
+github.com/cespare/xxhash/v2
 
-6. Trademarks. This License does not grant permission to use the trade
-names, trademarks, service marks, or product names of the Licensor,
-except as required for reasonable and customary use in describing the
-origin of the Work and reproducing the content of the NOTICE file.
+== License Type
+SPDX:MIT
 
-7. Disclaimer of Warranty. Unless required by applicable law or
-agreed to in writing, Licensor provides the Work (and each
-Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied, including, without limitation, any warranties or conditions
-of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any
-risks associated with Your exercise of permissions under this License.
+== Copyright
+Copyright (c) 2016 Caleb Spare
 
-8. Limitation of Liability. In no event and under no legal theory,
-whether in tort (including negligence), contract, or otherwise,
-unless required by applicable law (such as deliberate and grossly
-negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a
-result of this License or out of the use or inability to use the
-Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
+--------------------------------- (separator) ----------------------------------
 
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer,
-and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify,
-defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
+== Dependency
+github.com/cisco-open/k8s-objectmatcher
 
-END OF TERMS AND CONDITIONS
+== License Type
+SPDX:Apache-2.0
 
-APPENDIX: How to apply the Apache License to your work.
+== Copyright
+Copyright (c) 2017-2019 [Banzai Cloud, Inc.](https://banzaicloud.com)
+Copyright © 2019 Banzai Cloud
+Copyright © 2021 Banzai Cloud
+Copyright © 2022 Banzai Cloud
 
-To apply the Apache License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets "{}"
-replaced with your own identifying information. (Don't include
-the brackets!)  The text should be enclosed in the appropriate
-comment syntax for the file format. We also recommend that a
-file or class name and description of purpose be included on the
-same "printed page" as the copyright notice for easier
-identification within third-party archives.
+== Notices
+Copyright © 2019 Banzai Cloud
 
-Copyright {yyyy} {name of copyright owner}
+Portions of this software were developed in the Kubernetes project: https://github.com/kubernetes/kubernetes
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+The source file patch/annotation.go is based on https://github.com/kubernetes/kubernetes/blob/3d0c961d57bb90c112a0ee2f5ccdcb5c8570ad32/pkg/kubectl/apply.go
+The source file patch/deletenull.go is based on https://github.com/kubernetes/kubernetes/blob/433b448e8d42da70df5d50f4ce667bcb36aeeec2/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
 
 
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-gopkg.in/yaml.v3
--------- Copyrights
-Copyright (c) 2011-2019 Canonical Ltd
-Copyright (c) 2006-2010 Kirill Simonov
-Copyright (c) 2006-2011 Kirill Simonov
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/cisco-open/operator-tools
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright © 2020 Banzai Cloud
+Copyright © 2022 Banzai Cloud
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/cppforlife/go-patch
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2016 Dmitriy Kalinin
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/davecgh/go-spew
+
+== License Type
+=== ISC-c06795ed
+ISC License
+
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+
+== Copyright
+Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
+Copyright (c) 2013 Dave Collins <dave@davec.name>
+Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
+Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/emicklei/go-restful/v3
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2012,2013 Ernest Micklei
+Copyright 2013 Ernest Micklei. All rights reserved.
+Copyright 2014 Ernest Micklei. All rights reserved.
+Copyright 2015 Ernest Micklei. All rights reserved.
+Copyright 2018 Ernest Micklei. All rights reserved.
+Copyright 2021 Ernest Micklei. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/evanphx/json-patch
+
+== License Type
+=== BSD-3-Clause-96ae735c
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+== Copyright
+Copyright (c) 2014, Evan Phoenix
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/evanphx/json-patch/v5
+
+== License Type
+=== BSD-3-Clause-96ae735c
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+== Copyright
+Copyright (c) 2014, Evan Phoenix
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/fatih/color
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2013 Fatih Arslan
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/fsnotify/fsnotify
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright © 2012 The Go Authors. All rights reserved.
+Copyright © fsnotify Authors. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/go-logr/logr
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2019 The logr Authors.
+Copyright 2020 The logr Authors.
+Copyright 2021 The logr Authors.
+Copyright 2022 The logr Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/go-logr/zapr
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2018 Solly Ross
+Copyright 2019 The logr Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The logr Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/go-openapi/jsonpointer
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2013 sigu-399 ( https://github.com/sigu-399 )
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/go-openapi/jsonreference
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2013 sigu-399 ( https://github.com/sigu-399 )
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/go-openapi/swag
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2015 go-swagger maintainers
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/gogo/protobuf
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2013, The GoGo Authors. All rights reserved.
+Copyright (c) 2015, The GoGo Authors.  rights reserved.
+Copyright (c) 2015, The GoGo Authors. All rights reserved.
+Copyright (c) 2016, The GoGo Authors. All rights reserved.
+Copyright (c) 2017, The GoGo Authors. All rights reserved.
+Copyright (c) 2018, The GoGo Authors. All rights reserved.
+Copyright (c) 2019, The GoGo Authors. All rights reserved.
+Copyright 2010 The Go Authors.
+Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2011 The Go Authors.  All rights reserved.
+Copyright 2012 The Go Authors.  All rights reserved.
+Copyright 2013 The Go Authors.  All rights reserved.
+Copyright 2014 The Go Authors.  All rights reserved.
+Copyright 2015 The Go Authors.  All rights reserved.
+Copyright 2016 The Go Authors.  All rights reserved.
+Copyright 2017 The Go Authors.  All rights reserved.
+Copyright 2018 The Go Authors.  All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/golang/groupcache
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2012 Google Inc.
+Copyright 2013 Google Inc.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/golang/protobuf
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors.  All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/google/gnostic
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2017 Google LLC. All Rights Reserved.
+Copyright 2017-2020, Google LLC.
+Copyright 2018 Google LLC. All Rights Reserved.
+Copyright 2019 Google LLC. All Rights Reserved.
+Copyright 2020 Google LLC. All Rights Reserved.
+Copyright 2020 Google LLC. All Rights Reserved.\n" +
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/google/go-cmp
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2017 The Go Authors. All rights reserved.
+Copyright 2017, The Go Authors. All rights reserved.
+Copyright 2018, The Go Authors. All rights reserved.
+Copyright 2019, The Go Authors. All rights reserved.
+Copyright 2020, The Go Authors. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/google/gofuzz
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2014 Google Inc. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/google/uuid
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+Copyright 2016 Google Inc.  All rights reserved.
+Copyright 2017 Google Inc.  All rights reserved.
+Copyright 2018 Google Inc.  All rights reserved.
+Copyright 2021 Google Inc.  All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/hashicorp/go-version
+
+== License Type
+SPDX:MPL-2.0
+
+== Copyright
+(no copyright notices found)
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/iancoleman/orderedmap
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2017 Ian Coleman
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/imdario/mergo
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2013 Dario Castañé. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2013 Dario Castañé. All rights reserved.
+Copyright 2014 Dario Castañé. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/josharian/intern
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2019 Josh Bleecher Snyder
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/json-iterator/go
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2016 json-iterator
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/mailru/easyjson
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright (c) 2016 Mail.Ru Group
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/mattn/go-colorable
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2016 Yasuhiro Matsumoto
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/mattn/go-isatty
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/matttproud/golang_protobuf_extensions
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+Copyright 2013 Matt T. Proud
+Copyright 2016 Matt T. Proud
+
+== Notices
+Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/modern-go/concurrent
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+(no copyright notices found)
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/modern-go/reflect2
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+(no copyright notices found)
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/munnerz/goautoneg
+
+== License Type
+=== BSD-3-Clause-0c241922
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+    Neither the name of the Open Knowledge Foundation Ltd. nor the
+    names of its contributors may be used to endorse or promote
+    products derived from this software without specific prior written
+    permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+== Copyright
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/onsi/ginkgo/v2
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2013-2014 Onsi Fakhouri
+Copyright (c) 2016 Yasuhiro Matsumoto
+Copyright 2013 The Go Authors. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/onsi/gomega
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2013-2014 Onsi Fakhouri
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/opensearch-project/opensearch-go
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2021 OpenSearch Contributors
+
+== Notices
+OpenSearch (https://opensearch.org/)
+Copyright 2021 OpenSearch Contributors
+
+This product includes software developed by
+Elasticsearch (http://www.elastic.co).
+
+This product includes software developed by The Apache Software
+Foundation (http://www.apache.org/).
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/pkg/errors
+
+== License Type
+SPDX:BSD-2-Clause
+
+== Copyright
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2017 The prometheus-operator Authors
+Copyright 2018 The prometheus-operator Authors
+Copyright 2020 The prometheus-operator Authors
+Copyright 2021 The prometheus-operator Authors
+Copyright 2022 The prometheus-operator Authors
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/prometheus/client_golang
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright (c) 2013, The Prometheus Authors
+Copyright (c) 2015 Björn Rabenstein
+Copyright 2010 The Go Authors
+Copyright 2012-2015 The Prometheus Authors
+Copyright 2013 Matt T. Proud
+Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
+Copyright 2014 The Prometheus Authors
+Copyright 2015 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+Copyright 2018 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2022 The Prometheus Authors
+
+== Notices
+Prometheus instrumentation library for Go applications
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+The following components are included in this product:
+
+perks - a fork of https://github.com/bmizerany/perks
+https://github.com/beorn7/perks
+Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
+See https://github.com/beorn7/perks/blob/master/README.md for license details.
+
+Go support for Protocol Buffers - Google's data interchange format
+http://github.com/golang/protobuf/
+Copyright 2010 The Go Authors
+See source code for license details.
+
+Support for streaming Protocol Buffer messages for the Go language (golang).
+https://github.com/matttproud/golang_protobuf_extensions
+Copyright 2013 Matt T. Proud
+Licensed under the Apache License, Version 2.0
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/prometheus/client_model
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2012-2015 The Prometheus Authors
+Copyright 2013 Prometheus Team
+
+== Notices
+Data model artifacts for Prometheus.
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/prometheus/common
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+Copyright 2013 The Prometheus Authors
+Copyright 2014 The Prometheus Authors
+Copyright 2015 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+Copyright 2018 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright 2020 The Prometheus-operator Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2022 The Prometheus Authors
+
+== Notices
+Common libraries shared by Prometheus Go components.
+Copyright 2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/prometheus/procfs
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2014 Prometheus Team
+Copyright 2014-2015 The Prometheus Authors
+Copyright 2017 Prometheus Team
+Copyright 2017 The Prometheus Authors
+Copyright 2018 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2022 The Prometheus Authors
+
+== Notices
+procfs provides functions to retrieve system, kernel and process
+metrics from the pseudo-filesystem proc.
+
+Copyright 2014-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/samber/lo
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2022 Samuel Berthe
+Copyright © 2022 [Samuel Berthe](https://github.com/samber).
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/spf13/cast
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2014 Steve Francia
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright © 2014 Steve Francia <spf@spf13.com>.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/spf13/pflag
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+github.com/wayneashleyberry/terminal-dimensions
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2016 Wayne Ashley Berry
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+go.uber.org/atomic
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2016 Uber Technologies, Inc.
+Copyright (c) 2016-2020 Uber Technologies, Inc.
+Copyright (c) 2020 Uber Technologies, Inc.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+go.uber.org/multierr
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2019 Uber Technologies, Inc.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+go.uber.org/zap
+
+== License Type
+SPDX:MIT
+
+== Copyright
+Copyright (c) 2016 Uber Technologies, Inc.
+Copyright (c) 2016, 2017 Uber Technologies, Inc.
+Copyright (c) 2016-2017 Uber Technologies, Inc.
+Copyright (c) 2016-2022 Uber Technologies, Inc.
+Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2018 Uber Technologies, Inc.
+Copyright (c) 2020 Uber Technologies, Inc.
+Copyright (c) 2021 Uber Technologies, Inc.
+Copyright (c) 2022 Uber Technologies, Inc.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+golang.org/x/exp
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors.  All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors.  All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+
+== Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+golang.org/x/net
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2023 The Go Authors. All rights reserved.
+
+== Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+golang.org/x/oauth2
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2015 The oauth2 Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2017 The oauth2 Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2018 The oauth2 Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+golang.org/x/sys
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2009,2010 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All right reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2023 The Go Authors. All rights reserved.
+
+== Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+golang.org/x/term
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+
+== Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+golang.org/x/text
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+
+== Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+golang.org/x/time
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+
+== Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+gomodules.xyz/jsonpatch/v2
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+(no copyright notices found)
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+google.golang.org/protobuf
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2018 The Go Authors. All rights reserved.
+Copyright 2008 Google Inc.  All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.",
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.",
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2023 The Go Authors. All rights reserved.
+
+== Patents
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+gopkg.in/inf.v0
+
+== License Type
+SPDX:BSD-3-Clause--modified-by-Google
+
+== Copyright
+Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+gopkg.in/yaml.v2
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright (c) 2006 Kirill Simonov
 Copyright 2011-2016 Canonical Ltd.
--------- Notices
+
+== Notices
 Copyright 2011-2016 Canonical Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -232,10 +1320,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
--------- Dependencies Summary
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 gopkg.in/yaml.v3
 
--------- License used by Dependencies
+== License Type
+=== MIT-3c91c172
+=== Apache-2.0
 
 This project is covered by two different licenses: MIT and Apache.
 
@@ -288,283 +1380,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-cloud.google.com/go
--------- Copyrights
-Copyright 2016 Google LLC
-Copyright 2019 Google LLC
-Copyright 2018 Google LLC
-Copyright (c) 1996-1998 John D. Polstra.  All rights reserved.
-Copyright (c) 2001 David E. O'Brien
-Copyright 2018 Google LLC.
-Copyright 2021 Google LLC
-Copyright 2014 Google LLC
-Copyright 2018 Google Inc. All Rights Reserved.
-Copyright 2017 Google LLC
-Copyright 2020 Google LLC
-Copyright 2020, Google LLC
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2012 Google, Inc. Package foo does bar.", 27, ""},
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright (c) 2020 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
 
--------- Dependency
-github.com/Azure/go-autorest/autorest
--------- Copyrights
-Copyright 2017 Microsoft Corporation
-Copyright 2015 Microsoft Corporation
-
--------- Dependency
-github.com/Azure/go-autorest/autorest/adal
--------- Copyrights
-Copyright 2017 Microsoft Corporation
-Copyright 2015 Microsoft Corporation
-
--------- Dependency
-github.com/Azure/go-autorest/autorest/date
--------- Copyrights
-Copyright 2017 Microsoft Corporation
-Copyright 2015 Microsoft Corporation
-
--------- Dependency
-github.com/Azure/go-autorest/logger
--------- Copyrights
-Copyright 2017 Microsoft Corporation
-Copyright 2015 Microsoft Corporation
-
--------- Dependency
-github.com/Azure/go-autorest/tracing
--------- Copyrights
-Copyright 2018 Microsoft Corporation
-Copyright 2017 Microsoft Corporation
-Copyright 2015 Microsoft Corporation
-
--------- Dependency
-github.com/banzaicloud/k8s-objectmatcher
--------- Copyrights
-Copyright (c) 2017-2019 [Banzai Cloud, Inc.](https://banzaicloud.com)
-Copyright © 2019 Banzai Cloud
-Copyright © 2021 Banzai Cloud
-Copyright © 2022 Banzai Cloud
--------- Notices
-Copyright © 2019 Banzai Cloud
-
-Portions of this software were developed in the Kubernetes project: https://github.com/kubernetes/kubernetes
-
-The source file patch/annotation.go is based on https://github.com/kubernetes/kubernetes/blob/3d0c961d57bb90c112a0ee2f5ccdcb5c8570ad32/pkg/kubectl/apply.go
-The source file patch/deletenull.go is based on https://github.com/kubernetes/kubernetes/blob/433b448e8d42da70df5d50f4ce667bcb36aeeec2/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go
-
-
--------- Dependency
-github.com/banzaicloud/operator-tools
--------- Copyrights
-Copyright © 2020 Banzai Cloud
-Copyright © 2022 Banzai Cloud
-
--------- Dependency
-github.com/briandowns/spinner
--------- Copyrights
-  (no copyright notices found)
-
--------- Dependency
-github.com/go-logr/logr
--------- Copyrights
-Copyright 2020 The logr Authors.
-Copyright 2021 The logr Authors.
-Copyright 2019 The logr Authors.
-
--------- Dependency
-github.com/go-logr/zapr
--------- Copyrights
-Copyright 2019 The logr Authors.
-Copyright 2021 The logr Authors.
-Copyright 2018 Solly Ross
-Copyright 2020 The Kubernetes Authors.
-
--------- Dependency
-github.com/go-openapi/jsonpointer
--------- Copyrights
-Copyright 2013 sigu-399 ( https://github.com/sigu-399 )
-
--------- Dependency
-github.com/go-openapi/jsonreference
--------- Copyrights
-Copyright 2013 sigu-399 ( https://github.com/sigu-399 )
-
--------- Dependency
-github.com/go-openapi/swag
--------- Copyrights
-Copyright 2015 go-swagger maintainers
-
--------- Dependency
-github.com/golang/groupcache
--------- Copyrights
-Copyright 2012 Google Inc.
-Copyright 2013 Google Inc.
-
--------- Dependency
-github.com/google/gnostic
--------- Copyrights
-Copyright 2017-2020, Google LLC.
-Copyright 2019 Google LLC. All Rights Reserved.
-Copyright 2017 Google LLC. All Rights Reserved.
-Copyright 2018 Google LLC. All Rights Reserved.
-Copyright 2020 Google LLC. All Rights Reserved.
-Copyright 2020 Google LLC. All Rights Reserved.\n" +
-
--------- Dependency
-github.com/google/gofuzz
--------- Copyrights
-Copyright 2014 Google Inc. All rights reserved.
-
--------- Dependency
-github.com/matttproud/golang_protobuf_extensions
--------- Copyrights
-Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
-Copyright 2016 Matt T. Proud
-Copyright 2013 Matt T. Proud
--------- Notices
-Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
-
-
--------- Dependency
-github.com/modern-go/concurrent
--------- Copyrights
-  (no copyright notices found)
-
--------- Dependency
-github.com/modern-go/reflect2
--------- Copyrights
-  (no copyright notices found)
-
--------- Dependency
-github.com/opensearch-project/opensearch-go
--------- Copyrights
-Copyright 2021 OpenSearch Contributors
--------- Notices
-OpenSearch (https://opensearch.org/)
-Copyright 2021 OpenSearch Contributors
-
-This product includes software developed by
-Elasticsearch (http://www.elastic.co).
-
-This product includes software developed by The Apache Software
-Foundation (http://www.apache.org/).
-
--------- Dependency
-github.com/prometheus/client_golang
--------- Copyrights
-Copyright 2018 The Prometheus Authors
-Copyright 2012-2015 The Prometheus Authors
-Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
-Copyright 2010 The Go Authors
-Copyright 2013 Matt T. Proud
-Copyright 2015 The Prometheus Authors
-Copyright 2017 The Prometheus Authors
-Copyright 2019 The Prometheus Authors
-Copyright 2022 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
-Copyright 2014 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
-Copyright 2016 The Prometheus Authors
-Copyright (c) 2013, The Prometheus Authors
--------- Notices
-Prometheus instrumentation library for Go applications
-Copyright 2012-2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
-
-
-The following components are included in this product:
-
-perks - a fork of https://github.com/bmizerany/perks
-https://github.com/beorn7/perks
-Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
-See https://github.com/beorn7/perks/blob/master/README.md for license details.
-
-Go support for Protocol Buffers - Google's data interchange format
-http://github.com/golang/protobuf/
-Copyright 2010 The Go Authors
-See source code for license details.
-
-Support for streaming Protocol Buffer messages for the Go language (golang).
-https://github.com/matttproud/golang_protobuf_extensions
-Copyright 2013 Matt T. Proud
-Licensed under the Apache License, Version 2.0
-
-
--------- Dependency
-github.com/prometheus/client_model
--------- Copyrights
-Copyright 2013 Prometheus Team
-Copyright 2012-2015 The Prometheus Authors
--------- Notices
-Data model artifacts for Prometheus.
-Copyright 2012-2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
-
-
--------- Dependency
-github.com/prometheus/common
--------- Copyrights
-Copyright 2018 The Prometheus Authors
-Copyright 2015 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
-Copyright 2016 The Prometheus Authors
-Copyright 2014 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
-Copyright (c) 2011, Open Knowledge Foundation Ltd.
-Copyright 2013 The Prometheus Authors
-Copyright 2019 The Prometheus Authors
-Copyright 2017 The Prometheus Authors
--------- Notices
-Common libraries shared by Prometheus Go components.
-Copyright 2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
-
-
--------- Dependency
-github.com/prometheus/procfs
--------- Copyrights
-Copyright 2019 The Prometheus Authors
-Copyright 2018 The Prometheus Authors
-Copyright 2014-2015 The Prometheus Authors
-Copyright 2017 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
-Copyright 2014 Prometheus Team
-Copyright 2017 Prometheus Team
--------- Notices
-procfs provides functions to retrieve system, kernel and process
-metrics from the pseudo-filesystem proc.
-
-Copyright 2014-2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
-
-
--------- Dependency
-gomodules.xyz/jsonpatch/v2
--------- Copyrights
-  (no copyright notices found)
-
--------- Dependency
-gopkg.in/yaml.v2
--------- Copyrights
+== Copyright
+Copyright (c) 2006-2010 Kirill Simonov
+Copyright (c) 2006-2011 Kirill Simonov
+Copyright (c) 2011-2019 Canonical Ltd
 Copyright 2011-2016 Canonical Ltd.
-Copyright (c) 2006 Kirill Simonov
--------- Notices
+
+== Notices
 Copyright 2011-2016 Canonical Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -580,180 +1403,539 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
--------- Dependency
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 k8s.io/api
--------- Copyrights
-Copyright 2019 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
 
--------- Dependency
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2015 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 k8s.io/apiextensions-apiserver
--------- Copyrights
-Copyright 2019 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2020 Google LLC
-Copyright 2022 Google LLC
 
--------- Dependency
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 k8s.io/apimachinery
--------- Copyrights
-Copyright 2021 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
 Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
--------- Dependency
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 k8s.io/client-go
--------- Copyrights
-Copyright 2021 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
 Copyright (c) 2009 The Go Authors. All rights reserved.
-
--------- Dependency
-k8s.io/component-base
--------- Copyrights
 Copyright 2014 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
 Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
-
--------- Dependency
-k8s.io/klog/v2
--------- Copyrights
-Copyright 2022 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+k8s.io/component-base
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2014 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+k8s.io/klog/v2
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
 Copyright 2013 Google Inc. All Rights Reserved.
 Copyright 2014 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
 Copyright 2020 Intel Coporation.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
--------- Dependency
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 k8s.io/kube-openapi
--------- Copyrights
-Copyright 2018 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2020 The Go Authors. All rights reserved.
-Copyright (c) 2020 The Go Authors. All rights reserved.
-Copyright 2022 The Go Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2015 go-swagger maintainers
-Copyright 2017 go-swagger maintainers
 
--------- Dependency
-k8s.io/utils
--------- Copyrights
-Copyright 2018 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright (C) MongoDB, Inc. 2017-present.
+Copyright (c) 2020 The Go Authors. All rights reserved.
+Copyright 2015 go-swagger maintainers
 Copyright 2016 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2017 go-swagger maintainers
+Copyright 2018 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
-Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Go Authors. All rights reserved.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+k8s.io/utils
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
 Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright 2013 Google Inc.
 Copyright 2009 The Go Authors. All rights reserved.
-
--------- Dependency
-sigs.k8s.io/controller-runtime
--------- Copyrights
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2013 Google Inc.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 Copyright 2018 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
-Copyright 2018 The Kubernetes authors.
+Copyright 2020 The Kubernetes Authors.
 Copyright 2021 The Kubernetes Authors.
 Copyright 2022 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
--------- Dependency
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+sigs.k8s.io/controller-runtime
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
+Copyright 2014 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018 The Kubernetes authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
+sigs.k8s.io/json
+
+== License Type
+=== BSD-3-Clause--modified-by-Google-545d3f23
+=== Apache-2.0
+Files other than internal/golang/* licensed under:
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+------------------
+
+internal/golang/* files licensed under:
+
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+== Copyright
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2021 The Kubernetes Authors.
+
+--------------------------------- (separator) ----------------------------------
+
+== Dependency
 sigs.k8s.io/structured-merge-diff/v4
--------- Copyrights
+
+== License Type
+SPDX:Apache-2.0
+
+== Copyright
 Copyright 2018 The Kubernetes Authors.
 Copyright 2019 The Kubernetes Authors.
 Copyright 2020 The Kubernetes Authors.
 
--------- Dependencies Summary
-cloud.google.com/go
-github.com/Azure/go-autorest/autorest
-github.com/Azure/go-autorest/autorest/adal
-github.com/Azure/go-autorest/autorest/date
-github.com/Azure/go-autorest/logger
-github.com/Azure/go-autorest/tracing
-github.com/banzaicloud/k8s-objectmatcher
-github.com/banzaicloud/operator-tools
-github.com/briandowns/spinner
-github.com/go-logr/logr
-github.com/go-logr/zapr
-github.com/go-openapi/jsonpointer
-github.com/go-openapi/jsonreference
-github.com/go-openapi/swag
-github.com/golang/groupcache
-github.com/google/gnostic
-github.com/google/gofuzz
-github.com/matttproud/golang_protobuf_extensions
-github.com/modern-go/concurrent
-github.com/modern-go/reflect2
-github.com/opensearch-project/opensearch-go
-github.com/prometheus/client_golang
-github.com/prometheus/client_model
-github.com/prometheus/common
-github.com/prometheus/procfs
-gomodules.xyz/jsonpatch/v2
-gopkg.in/yaml.v2
-k8s.io/api
-k8s.io/apiextensions-apiserver
-k8s.io/apimachinery
-k8s.io/client-go
-k8s.io/component-base
-k8s.io/klog/v2
-k8s.io/kube-openapi
-k8s.io/utils
-sigs.k8s.io/controller-runtime
-sigs.k8s.io/structured-merge-diff/v4
+--------------------------------- (separator) ----------------------------------
 
--------- License used by Dependencies
+== Dependency
+sigs.k8s.io/yaml
+
+== License Type
+=== MIT-0ceb9ff3
+=== BSD-3-Clause--modified-by-Google
+The MIT License (MIT)
+
+Copyright (c) 2014 Sam Ghods
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+== Copyright
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2014 Sam Ghods
+Copyright 2013 The Go Authors. All rights reserved.
+
+----------------------------------- Licenses -----------------------------------
+
+--------------------------------- (separator) ----------------------------------
+== SPDX:Apache-2.0
+
 Apache License
 
 Version 2.0, January 2004
@@ -762,7 +1944,7 @@ http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-1. Definitions.
+1. Definitions. 
 
 "License" shall mean the terms and conditions for use, reproduction, and
 distribution as defined by Sections 1 through 9 of this document.
@@ -818,11 +2000,11 @@ in writing by the copyright owner as "Not a Contribution."
 of whom a Contribution has been received by Licensor and subsequently
 incorporated within the Work.
 
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form. 
 
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed. 
 
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions: 
 
 (a) You must give any other recipients of the Work or Derivative Works a copy
 of this License; and
@@ -855,15 +2037,15 @@ distribution of Your modifications, or for any such Derivative Works as a
 whole, provided Your use, reproduction, and distribution of the Work otherwise
 complies with the conditions stated in this License.
 
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions. 
 
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file. 
 
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License. 
 
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages. 
 
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability. 
 
 END OF TERMS AND CONDITIONS
 
@@ -899,108 +2081,23 @@ limitations under the License.
 
 
 
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-github.com/munnerz/goautoneg
--------- Copyrights
-Copyright (c) 2011, Open Knowledge Foundation Ltd.
-
--------- Dependencies Summary
-github.com/munnerz/goautoneg
-
--------- License used by Dependencies
-Copyright (c) 2011, Open Knowledge Foundation Ltd.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-
-    Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in
-    the documentation and/or other materials provided with the
-    distribution.
-
-    Neither the name of the Open Knowledge Foundation Ltd. nor the
-    names of its contributors may be used to endorse or promote
-    products derived from this software without specific prior written
-    permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-github.com/PuerkitoBio/purell
--------- Copyrights
-Copyright (c) 2012, Martin Angers
-
--------- Dependencies Summary
-github.com/PuerkitoBio/purell
-
--------- License used by Dependencies
-Copyright (c) 2012, Martin Angers
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-* Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-github.com/evanphx/json-patch
--------- Copyrights
-Copyright (c) 2014, Evan Phoenix
-
--------- Dependency
-github.com/evanphx/json-patch/v5
--------- Copyrights
-Copyright (c) 2014, Evan Phoenix
-
--------- Dependencies Summary
-github.com/evanphx/json-patch
-github.com/evanphx/json-patch/v5
-
--------- License used by Dependencies
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
+--------------------------------- (separator) ----------------------------------
+== SPDX:BSD-2-Clause
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
 FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
@@ -1009,36 +2106,13 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-sigs.k8s.io/json
--------- Copyrights
-Copyright 2021 The Kubernetes Authors.
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
 
--------- Dependencies Summary
-sigs.k8s.io/json
+--------------------------------- (separator) ----------------------------------
+== SPDX:BSD-3-Clause--modified-by-Google
 
--------- License used by Dependencies
-Files other than internal/golang/* licensed under: Apache 2.0 (See actual license text in main license section above)
-
-------------------
-
-internal/golang/* files licensed under:
-
-
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
+Redistribution and use in source and binary forms, with
+or without modification, are permitted provided that the following conditions
+are met:
 
    * Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
@@ -1063,49 +2137,35 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-github.com/davecgh/go-spew
--------- Copyrights
-Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
-Copyright (c) 2013-2016 Dave Collins <dave@davec.name>
-Copyright (c) 2015-2016 Dave Collins <dave@davec.name>
-Copyright (c) 2013 Dave Collins <dave@davec.name>
+--------------------------------- (separator) ----------------------------------
+== SPDX:MIT
 
--------- Dependencies Summary
-github.com/davecgh/go-spew
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
--------- License used by Dependencies
-ISC License
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Copyright (c) 2012-2016 Dave Collins <dave@davec.name>
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-github.com/hashicorp/go-version
--------- Copyrights
-  (no copyright notices found)
 
--------- Dependencies Summary
-github.com/hashicorp/go-version
+--------------------------------- (separator) ----------------------------------
+== SPDX:MPL-2.0
 
--------- License used by Dependencies
 Mozilla Public License Version 2.0
 
-1. Definitions
+1. Definitions 
 
 1.1. "Contributor" means each individual or legal entity that creates,
 contributes to the creation of, or owns Covered Software.
@@ -1169,7 +2229,7 @@ cause the direction or management of such entity, whether by contract or
 otherwise, or (b) ownership of more than fifty percent (50%) of the
 outstanding shares or beneficial ownership of such entity.
 
-2. License Grants and Conditions
+2. License Grants and Conditions 
 
 2.1. Grants
 
@@ -1236,7 +2296,7 @@ copyright doctrines of fair use, fair dealing, or other equivalents.
 Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
 Section 2.1.
 
-3. Responsibilities
+3. Responsibilities 
 
 3.1. Distribution of Source Form
 
@@ -1294,7 +2354,7 @@ Contributor as a result of warranty, support, indemnity or liability terms You
 offer. You may include additional disclaimers of warranty and limitations of
 liability specific to any jurisdiction.
 
-4. Inability to Comply Due to Statute or Regulation
+4. Inability to Comply Due to Statute or Regulation   
 If it is impossible for You to comply with any of the terms of this License
 with respect to some or all of the Covered Software due to statute, judicial
 order, or regulation then You must: (a) comply with the terms of this License
@@ -1304,7 +2364,7 @@ distributions of the Covered Software under this License. Except to the extent
 prohibited by statute or regulation, such description must be sufficiently
 detailed for a recipient of ordinary skill to be able to understand it.
 
-5. Termination
+5. Termination 
 
 5.1. The rights granted under this License will terminate automatically if You
 fail to comply with any of its terms. However, if You become compliant, then
@@ -1331,7 +2391,7 @@ license agreements (excluding distributors and resellers) which have been
 validly granted by You or Your distributors under this License prior to
 termination shall survive termination.
 
-6. Disclaimer of Warranty
+6. Disclaimer of Warranty   
 Covered Software is provided under this License on an "as is" basis, without
 warranty of any kind, either expressed, implied, or statutory, including,
 without limitation, warranties that the Covered Software is free of defects,
@@ -1343,7 +2403,7 @@ disclaimer of warranty constitutes an essential part of this License. No use
 of any Covered Software is authorized under this License except under this
 disclaimer.
 
-7. Limitation of Liability
+7. Limitation of Liability   
 Under no circumstances and under no legal theory, whether tort (including
 negligence), contract, or otherwise, shall any Contributor, or anyone who
 distributes Covered Software as permitted above, be liable to You for any
@@ -1357,14 +2417,14 @@ negligence to the extent applicable law prohibits such limitation. Some
 jurisdictions do not allow the exclusion or limitation of incidental or
 consequential damages, so this exclusion and limitation may not apply to You.
 
-8. Litigation
+8. Litigation   
 Any litigation relating to this License may be brought only in the courts of a
 jurisdiction where the defendant maintains its principal place of business and
 such litigation shall be governed by laws of that jurisdiction, without
 reference to its conflict-of-law provisions. Nothing in this Section shall
 prevent a party&apos;s ability to bring cross-claims or counter-claims.
 
-9. Miscellaneous
+9. Miscellaneous   
 This License represents the complete agreement concerning the subject matter
 hereof. If any provision of this License is held to be unenforceable, such
 provision shall be reformed only to the extent necessary to make it
@@ -1372,7 +2432,7 @@ enforceable. Any law or regulation which provides that the language of a
 contract shall be construed against the drafter shall not be used to construe
 this License against a Contributor.
 
-10. Versions of the License
+10. Versions of the License 
 
 10.1. New Versions
 
@@ -1421,700 +2481,6 @@ This Source Code Form is "Incompatible With Secondary Licenses", as defined by
 the Mozilla Public License, v. 2.0.
 
 
-
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-emperror.dev/errors
--------- Copyrights
-Copyright (c) 2019 Márk Sági-Kazár <mark.sagikazar@gmail.com>
-Copyright (c) 2015, Dave Cheney <dave@cheney.net>
-Copyright (c) 2019 The Go Authors. All rights reserved.
-Copyright 2015 Dave Cheney <dave@cheney.net>. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-
--------- Dependency
-github.com/Masterminds/semver
--------- Copyrights
-Copyright (C) 2014-2019, Matt Butcher and Matt Farina
-
--------- Dependency
-github.com/beorn7/perks
--------- Copyrights
-Copyright (C) 2013 Blake Mizerany
-
--------- Dependency
-github.com/cespare/xxhash/v2
--------- Copyrights
-Copyright (c) 2016 Caleb Spare
-
--------- Dependency
-github.com/cppforlife/go-patch
--------- Copyrights
-Copyright (c) 2016 Dmitriy Kalinin
-
--------- Dependency
-github.com/emicklei/go-restful/v3
--------- Copyrights
-Copyright 2013 Ernest Micklei. All rights reserved.
-Copyright 2015 Ernest Micklei. All rights reserved.
-Copyright (c) 2012,2013 Ernest Micklei
-Copyright 2021 Ernest Micklei. All rights reserved.
-Copyright 2014 Ernest Micklei. All rights reserved.
-Copyright 2018 Ernest Micklei. All rights reserved.
-
--------- Dependency
-github.com/fatih/color
--------- Copyrights
-Copyright (c) 2013 Fatih Arslan
-
--------- Dependency
-github.com/golang-jwt/jwt/v4
--------- Copyrights
-Copyright (c) 2012 Dave Grijalva
-Copyright (c) 2021 golang-jwt maintainers
-
--------- Dependency
-github.com/iancoleman/orderedmap
--------- Copyrights
-Copyright (c) 2017 Ian Coleman
-
--------- Dependency
-github.com/josharian/intern
--------- Copyrights
-Copyright (c) 2019 Josh Bleecher Snyder
-
--------- Dependency
-github.com/json-iterator/go
--------- Copyrights
-Copyright (c) 2016 json-iterator
-
--------- Dependency
-github.com/mailru/easyjson
--------- Copyrights
-Copyright (c) 2016 Mail.Ru Group
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
--------- Dependency
-github.com/mattn/go-colorable
--------- Copyrights
-Copyright (c) 2016 Yasuhiro Matsumoto
-
--------- Dependency
-github.com/mattn/go-isatty
--------- Copyrights
-  (no copyright notices found)
-
--------- Dependency
-github.com/spf13/cast
--------- Copyrights
-Copyright © 2014 Steve Francia <spf@spf13.com>.
-Copyright (c) 2014 Steve Francia
-Copyright 2011 The Go Authors. All rights reserved.
-
--------- Dependency
-github.com/wayneashleyberry/terminal-dimensions
--------- Copyrights
-Copyright (c) 2016 Wayne Ashley Berry
-
--------- Dependency
-go.uber.org/atomic
--------- Copyrights
-Copyright (c) 2020 Uber Technologies, Inc.
-Copyright (c) 2016 Uber Technologies, Inc.
-Copyright (c) 2016-2020 Uber Technologies, Inc.
-
--------- Dependency
-go.uber.org/multierr
--------- Copyrights
-Copyright (c) 2017 Uber Technologies, Inc.
-Copyright (c) 2019 Uber Technologies, Inc.
-
--------- Dependency
-go.uber.org/zap
--------- Copyrights
-Copyright (c) 2016 Uber Technologies, Inc.
-Copyright (c) 2016-2017 Uber Technologies, Inc.
-Copyright (c) 2017 Uber Technologies, Inc.
-Copyright (c) 2020 Uber Technologies, Inc.
-Copyright (c) 2021 Uber Technologies, Inc.
-Copyright (c) 2016, 2017 Uber Technologies, Inc.
-Copyright (c) 2018 Uber Technologies, Inc.
-
--------- Dependencies Summary
-emperror.dev/errors
-github.com/Masterminds/semver
-github.com/beorn7/perks
-github.com/cespare/xxhash/v2
-github.com/cppforlife/go-patch
-github.com/emicklei/go-restful/v3
-github.com/fatih/color
-github.com/golang-jwt/jwt/v4
-github.com/iancoleman/orderedmap
-github.com/josharian/intern
-github.com/json-iterator/go
-github.com/mailru/easyjson
-github.com/mattn/go-colorable
-github.com/mattn/go-isatty
-github.com/spf13/cast
-github.com/wayneashleyberry/terminal-dimensions
-go.uber.org/atomic
-go.uber.org/multierr
-go.uber.org/zap
-
--------- License used by Dependencies
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-github.com/PuerkitoBio/urlesc
--------- Copyrights
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
--------- Dependency
-github.com/fsnotify/fsnotify
--------- Copyrights
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
-Copyright 2022 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-
--------- Dependency
-github.com/gogo/protobuf
--------- Copyrights
-Copyright (c) 2013, The GoGo Authors. All rights reserved.
-Copyright 2010 The Go Authors.  All rights reserved.
-Copyright 2010 The Go Authors.
-Copyright (c) 2015, The GoGo Authors. All rights reserved.
-Copyright 2016 The Go Authors.  All rights reserved.
-Copyright 2015 The Go Authors.  All rights reserved.
-Copyright (c) 2018, The GoGo Authors. All rights reserved.
-Copyright 2011 The Go Authors.  All rights reserved.
-Copyright (c) 2016, The GoGo Authors. All rights reserved.
-Copyright 2018 The Go Authors.  All rights reserved.
-Copyright 2017 The Go Authors.  All rights reserved.
-Copyright 2014 The Go Authors.  All rights reserved.
-Copyright 2012 The Go Authors.  All rights reserved.
-Copyright 2013 The Go Authors.  All rights reserved.
-Copyright (c) 2019, The GoGo Authors. All rights reserved.
-Copyright (c) 2017, The GoGo Authors. All rights reserved.
-Copyright (c) 2015, The GoGo Authors.  rights reserved.
-
--------- Dependency
-github.com/golang/protobuf
--------- Copyrights
-Copyright 2010 The Go Authors.  All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors.  All rights reserved.
-
--------- Dependency
-github.com/google/go-cmp
--------- Copyrights
-Copyright (c) 2017 The Go Authors. All rights reserved.
-Copyright 2018, The Go Authors. All rights reserved.
-Copyright 2017, The Go Authors. All rights reserved.
-Copyright 2020, The Go Authors. All rights reserved.
-Copyright 2019, The Go Authors. All rights reserved.
-
--------- Dependency
-github.com/google/uuid
--------- Copyrights
-Copyright 2016 Google Inc.  All rights reserved.
-Copyright 2017 Google Inc.  All rights reserved.
-Copyright 2021 Google Inc.  All rights reserved.
-Copyright (c) 2009,2014 Google Inc. All rights reserved.
-Copyright 2018 Google Inc.  All rights reserved.
-
--------- Dependency
-github.com/imdario/mergo
--------- Copyrights
-Copyright 2013 Dario Castañé. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright (c) 2013 Dario Castañé. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright 2014 Dario Castañé. All rights reserved.
-
--------- Dependency
-github.com/spf13/pflag
--------- Copyrights
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright (c) 2012 Alex Ogier. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors.  All rights reserved.
-
--------- Dependency
-golang.org/x/crypto
--------- Copyrights
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright (c) 2017 The Go Authors. All rights reserved.
-Copyright (c) 2019 The Go Authors. All rights reserved.
-Copyright (c) 2021 The Go Authors. All rights reserved.
-Copyright (c) 2020 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
-Copyright 2022 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
--------- Patents
-Additional IP Rights Grant (Patents)
-
-"This implementation" means the copyrightable works distributed by
-Google as part of the Go project.
-
-Google hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section)
-patent license to make, have made, use, offer to sell, sell, import,
-transfer and otherwise run, modify and propagate the contents of this
-implementation of Go, where such license applies only to those patent
-claims, both currently owned or controlled by Google and acquired in
-the future, licensable by Google that are necessarily infringed by this
-implementation of Go.  This grant does not include claims that would be
-infringed only as a consequence of further modification of this
-implementation.  If you or your agent or exclusive licensee institute or
-order or agree to the institution of patent litigation against any
-entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that this implementation of Go or any code incorporated within this
-implementation of Go constitutes direct or contributory patent
-infringement, or inducement of patent infringement, then any patent
-rights granted to you under this License for this implementation of Go
-shall terminate as of the date such litigation is filed.
-
-
--------- Dependency
-golang.org/x/net
--------- Copyrights
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright (C) 2009 Apple Inc. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2022 The Go Authors. All rights reserved.
--------- Patents
-Additional IP Rights Grant (Patents)
-
-"This implementation" means the copyrightable works distributed by
-Google as part of the Go project.
-
-Google hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section)
-patent license to make, have made, use, offer to sell, sell, import,
-transfer and otherwise run, modify and propagate the contents of this
-implementation of Go, where such license applies only to those patent
-claims, both currently owned or controlled by Google and acquired in
-the future, licensable by Google that are necessarily infringed by this
-implementation of Go.  This grant does not include claims that would be
-infringed only as a consequence of further modification of this
-implementation.  If you or your agent or exclusive licensee institute or
-order or agree to the institution of patent litigation against any
-entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that this implementation of Go or any code incorporated within this
-implementation of Go constitutes direct or contributory patent
-infringement, or inducement of patent infringement, then any patent
-rights granted to you under this License for this implementation of Go
-shall terminate as of the date such litigation is filed.
-
-
--------- Dependency
-golang.org/x/oauth2
--------- Copyrights
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2017 The oauth2 Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
-Copyright 2015 The oauth2 Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2018 The oauth2 Authors. All rights reserved.
-
--------- Dependency
-golang.org/x/sys
--------- Copyrights
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2022 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2009,2010 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All right reserved.
--------- Patents
-Additional IP Rights Grant (Patents)
-
-"This implementation" means the copyrightable works distributed by
-Google as part of the Go project.
-
-Google hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section)
-patent license to make, have made, use, offer to sell, sell, import,
-transfer and otherwise run, modify and propagate the contents of this
-implementation of Go, where such license applies only to those patent
-claims, both currently owned or controlled by Google and acquired in
-the future, licensable by Google that are necessarily infringed by this
-implementation of Go.  This grant does not include claims that would be
-infringed only as a consequence of further modification of this
-implementation.  If you or your agent or exclusive licensee institute or
-order or agree to the institution of patent litigation against any
-entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that this implementation of Go or any code incorporated within this
-implementation of Go constitutes direct or contributory patent
-infringement, or inducement of patent infringement, then any patent
-rights granted to you under this License for this implementation of Go
-shall terminate as of the date such litigation is filed.
-
-
--------- Dependency
-golang.org/x/term
--------- Copyrights
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
--------- Patents
-Additional IP Rights Grant (Patents)
-
-"This implementation" means the copyrightable works distributed by
-Google as part of the Go project.
-
-Google hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section)
-patent license to make, have made, use, offer to sell, sell, import,
-transfer and otherwise run, modify and propagate the contents of this
-implementation of Go, where such license applies only to those patent
-claims, both currently owned or controlled by Google and acquired in
-the future, licensable by Google that are necessarily infringed by this
-implementation of Go.  This grant does not include claims that would be
-infringed only as a consequence of further modification of this
-implementation.  If you or your agent or exclusive licensee institute or
-order or agree to the institution of patent litigation against any
-entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that this implementation of Go or any code incorporated within this
-implementation of Go constitutes direct or contributory patent
-infringement, or inducement of patent infringement, then any patent
-rights granted to you under this License for this implementation of Go
-shall terminate as of the date such litigation is filed.
-
-
--------- Dependency
-golang.org/x/text
--------- Copyrights
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
--------- Patents
-Additional IP Rights Grant (Patents)
-
-"This implementation" means the copyrightable works distributed by
-Google as part of the Go project.
-
-Google hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section)
-patent license to make, have made, use, offer to sell, sell, import,
-transfer and otherwise run, modify and propagate the contents of this
-implementation of Go, where such license applies only to those patent
-claims, both currently owned or controlled by Google and acquired in
-the future, licensable by Google that are necessarily infringed by this
-implementation of Go.  This grant does not include claims that would be
-infringed only as a consequence of further modification of this
-implementation.  If you or your agent or exclusive licensee institute or
-order or agree to the institution of patent litigation against any
-entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that this implementation of Go or any code incorporated within this
-implementation of Go constitutes direct or contributory patent
-infringement, or inducement of patent infringement, then any patent
-rights granted to you under this License for this implementation of Go
-shall terminate as of the date such litigation is filed.
-
-
--------- Dependency
-golang.org/x/time
--------- Copyrights
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
--------- Patents
-Additional IP Rights Grant (Patents)
-
-"This implementation" means the copyrightable works distributed by
-Google as part of the Go project.
-
-Google hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section)
-patent license to make, have made, use, offer to sell, sell, import,
-transfer and otherwise run, modify and propagate the contents of this
-implementation of Go, where such license applies only to those patent
-claims, both currently owned or controlled by Google and acquired in
-the future, licensable by Google that are necessarily infringed by this
-implementation of Go.  This grant does not include claims that would be
-infringed only as a consequence of further modification of this
-implementation.  If you or your agent or exclusive licensee institute or
-order or agree to the institution of patent litigation against any
-entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that this implementation of Go or any code incorporated within this
-implementation of Go constitutes direct or contributory patent
-infringement, or inducement of patent infringement, then any patent
-rights granted to you under this License for this implementation of Go
-shall terminate as of the date such litigation is filed.
-
-
--------- Dependency
-google.golang.org/protobuf
--------- Copyrights
-Copyright (c) 2018 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.",
-Copyright 2018 The Go Authors. All rights reserved.",
-Copyright 2008 Google Inc.  All rights reserved.
-Copyright 2021 The Go Authors. All rights reserved.
--------- Patents
-Additional IP Rights Grant (Patents)
-
-"This implementation" means the copyrightable works distributed by
-Google as part of the Go project.
-
-Google hereby grants to You a perpetual, worldwide, non-exclusive,
-no-charge, royalty-free, irrevocable (except as stated in this section)
-patent license to make, have made, use, offer to sell, sell, import,
-transfer and otherwise run, modify and propagate the contents of this
-implementation of Go, where such license applies only to those patent
-claims, both currently owned or controlled by Google and acquired in
-the future, licensable by Google that are necessarily infringed by this
-implementation of Go.  This grant does not include claims that would be
-infringed only as a consequence of further modification of this
-implementation.  If you or your agent or exclusive licensee institute or
-order or agree to the institution of patent litigation against any
-entity (including a cross-claim or counterclaim in a lawsuit) alleging
-that this implementation of Go or any code incorporated within this
-implementation of Go constitutes direct or contributory patent
-infringement, or inducement of patent infringement, then any patent
-rights granted to you under this License for this implementation of Go
-shall terminate as of the date such litigation is filed.
-
-
--------- Dependency
-gopkg.in/inf.v0
--------- Copyrights
-Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
-
--------- Dependencies Summary
-github.com/PuerkitoBio/urlesc
-github.com/fsnotify/fsnotify
-github.com/gogo/protobuf
-github.com/golang/protobuf
-github.com/google/go-cmp
-github.com/google/uuid
-github.com/imdario/mergo
-github.com/spf13/pflag
-golang.org/x/crypto
-golang.org/x/net
-golang.org/x/oauth2
-golang.org/x/sys
-golang.org/x/term
-golang.org/x/text
-golang.org/x/time
-google.golang.org/protobuf
-gopkg.in/inf.v0
-
--------- License used by Dependencies
-Redistribution and use in source and binary forms, with
-or without modification, are permitted provided that the following conditions
-are met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-github.com/pkg/errors
--------- Copyrights
-Copyright (c) 2015, Dave Cheney <dave@cheney.net>
-
--------- Dependencies Summary
-github.com/pkg/errors
-
--------- License used by Dependencies
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-sigs.k8s.io/yaml
--------- Copyrights
-Copyright 2013 The Go Authors. All rights reserved.
-Copyright (c) 2014 Sam Ghods
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
--------- Dependencies Summary
-sigs.k8s.io/yaml
-
--------- License used by Dependencies
-The MIT License (MIT)
-
-Copyright (c) 2014 Sam Ghods
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
 === ATTRIBUTION-HELPER-GENERATED:
-=== Attribution helper version: {Major:0 Minor:11 GitVersion:0.10.0-58-gdde2e03d GitCommit:dde2e03d0114e01b7189b036162a1340f9e630e8 GitTreeState:clean BuildDate:2022-09-19T14:22:19Z GoVersion:go1.19.1 Compiler:gc Platform:darwin/amd64}
-=== License file based on go.mod with md5 sum: 009cd43a782b56499b37ed96fd38fa66
+=== Attribution helper version: {Major:0 Minor:11 GitVersion:0.10.0-108-gc398c3cf-dirty GitCommit:c398c3cf1bca9bc72e2382e8918b1e9ccedd0816 GitTreeState:dirty BuildDate:2023-03-31T00:10:24Z GoVersion:go1.19 Compiler:gc Platform:darwin/amd64}
+=== License file based on go.mod with md5 sum:  d47acae7064d6aa86449543fd75ddc37


### PR DESCRIPTION
* Oracle build from source v2.4.0
* Change docker builds to use Oracle base image
* Add a BUILD_FROM_SOURCE_README.md file
* Add SECURITY.md file
* Add THIRD_PARTY_LICENSES.txt file

