### PR TITLE
update go version to v1.20.12

### DIFF
--- a/opensearch-operator/Dockerfile.oracle
+++ b/opensearch-operator/Dockerfile.oracle
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM  ghcr.io/verrazzano/golang:v1.20.10 as builder
+FROM  ghcr.io/verrazzano/golang:v1.20.12 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
update go version to v1.20.12 to build openSearch k8s operator.